### PR TITLE
Removed need to copy the original ISO into working directory

### DIFF
--- a/remaster.sh
+++ b/remaster.sh
@@ -8,9 +8,16 @@ sudo apt-get update && sudo apt-get install squashfs-tools
 
 # Step 1:
 # Make a parent directory for our Live USB
-mkdir ./livecdtmp
-cp $ORIGINAL_ISO_NAME ./livecdtmp
+mkdir -p ./livecdtmp
 cd ./livecdtmp
+
+if [[ -f "../$ORIGINAL_ISO_NAME" ]]; then
+	ORIGINAL_ISO_NAME="../$ORIGINAL_ISO_NAME"
+elif [[ ! -f "$ORIGINAL_ISO_NAME" ]]; then
+	echo "$PWD/$ORIGINAL_FILE_NAME cannot be found. Please specify its full path." >&2
+	exit 2
+fi
+
 
 # Step 2:
 mkdir mnt


### PR DESCRIPTION
Very useful script - thank you!

I was doing this in a low-storage environment and saw fit to remove the requirement to make a copy of the ISO in the working directory....

I have some other changes to push as well, maybe you want to give me the go ahead before I flood you with pull requests?
